### PR TITLE
fix(filters): make remove_filter index-based with bounds handling

### DIFF
--- a/insightlog/lib.py
+++ b/insightlog/lib.py
@@ -266,14 +266,21 @@ class InsightLogAnalyzer:
         """
         return self.__filters[index]
 
+
     def remove_filter(self, index):
         """
-        Remove one filter from filters list using it's index
-        :param index:
-        :return:
+        Remove one filter from filters list using its index.
+        Raises:
+            ValueError: if index is out of range.
         """
-        # BUG: This method does not remove by index
-        self.__filters.remove(index)
+        try:
+            self.__filters.pop(index)
+        except IndexError:
+            raise ValueError(f"Filter index out of range: {index}") from None
+
+
+
+
 
     def clear_all_filters(self):
         """


### PR DESCRIPTION
Problem
remove_filter(1) attempted value removal and raised ValueError.

Solution
- Use __filters.pop(index) with IndexError → ValueError mapping.
- Keep public API intact (index-only semantics).

Validation
- Full test suite: 6 passed locally (pytest).
- Verified by test_remove_filter_bug in tests/test_lib.py

Closes #1
